### PR TITLE
Add workflow to run `npm run bundle` after dependabot updates

### DIFF
--- a/.github/workflows/dependabot-bundle.yaml
+++ b/.github/workflows/dependabot-bundle.yaml
@@ -1,0 +1,33 @@
+name: Dependabot Bundle
+on: pull_request
+
+permissions: {}
+
+jobs:
+  dist:
+    runs-on: ubuntu-latest
+    if:
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.commits == 1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.DEPENDABOT_BUNDLE_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Bundle dist
+        run: npm run bundle
+
+      - name: Commit dist
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: '[dependabot skip] Bundle dist'

--- a/.github/workflows/dependabot-bundle.yaml
+++ b/.github/workflows/dependabot-bundle.yaml
@@ -10,10 +10,16 @@ jobs:
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.commits == 1
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.GW2LOAD_BOT_APP_ID }}
+          private-key: ${{ secrets.GW2LOAD_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.DEPENDABOT_BUNDLE_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
The new `dependabot-bundle.yaml` workflow runs on dependabot PRs and commits changes to the repo after running `npm run bundle`. It only runs when the PR has a single commit, to prevent infinite recursion or updating anything added manually.

It requires a `DEPENDABOT_BUNDLE_TOKEN` secret with a GitHub token with `contents: write` permissions to run.

We can wait with this PR until we have transferred this repo to the org, so I can setup a bot token instead of you having to create a PAT.

Here is an example PR where you can see the created commit: https://github.com/darthmaim/generate-loading-screen/pull/8 (I have since rebased this branch, so example PR contains an additional commit)